### PR TITLE
Fix doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ If you are using your own custom backend you can:
 
     from zero_downtime_migrations.backend.schema import DatabaseSchemaEditor
 
-    class YourCustomDatabaseWrapper(BaseWrapper):
+    class DatabaseWrapper(BaseWrapper):
         SchemaEditorClass = DatabaseSchemaEditor
 
 


### PR DESCRIPTION
We seemed to be unable to customize the name of DatabaseWrapper in recent Django, so I thought that should use the proper name. 
https://github.com/django/django/blob/master/django/db/utils.py#L203
Thank you for a wonderful library.